### PR TITLE
🔢 Fix role position in logs

### DIFF
--- a/logs/credits.md
+++ b/logs/credits.md
@@ -2,6 +2,7 @@ Copyright © ZRunner 2021
 Copyright © Leirof 2021 - 2022
 Copyright © Theaustudio 2021
 Copyright © Aeris One 2022
+Copyright © ascpial 2023
 
 Ce programme est régi par la licence CeCILL soumise au droit français et
 respectant les principes de diffusion des logiciels libres. Vous pouvez

--- a/logs/logs.py
+++ b/logs/logs.py
@@ -367,7 +367,7 @@ class Logs(commands.Cog):
         _yes = await self.bot._(role.guild.id, "logs._yes")
         _pos = await self.bot._(role.guild.id, "logs.role_created.pos")
         _ment = await self.bot._(role.guild.id, "logs.role_created.mentionnable")
-        data = [_pos + ' {role.position}',
+        data = [_pos + f' {role.position}',
                 _ment + ' ' + (_yes if role.mentionable else _no)]
         if role.color != discord.Color.default():
             data.append(await self.bot._(role.guild.id, "logs.role_created.color") + f' {role.color}')
@@ -395,7 +395,7 @@ class Logs(commands.Cog):
         _yes = await self.bot._(role.guild.id, "logs._yes")
         _pos = await self.bot._(role.guild.id, "logs.role_created.pos")
         _ment = await self.bot._(role.guild.id, "logs.role_created.mentionnable")
-        data = [_pos + ' {role.position}',
+        data = [_pos + f' {role.position}',
                 _ment + ' ' + (_yes if role.mentionable else _no)]
         if role.color != discord.Color.default():
             data.append(await self.bot._(role.guild.id, "logs.role_created.color") + f' {role.color}')


### PR DESCRIPTION
La position du rôle n'est pas affichée lors de la création ou de la suppression de rôle dans les logs.

Closes #12.