### PR TITLE
❎ Permission fixes for help command

### DIFF
--- a/antikikoo/antikikoo.py
+++ b/antikikoo/antikikoo.py
@@ -99,13 +99,14 @@ class Antikikoo(commands.Cog):
 
     @commands.group(name="antikikoo", aliases=["ak", "antitroll"])
     @commands.guild_only()
+    @commands.has_permissions(administrator=True)
     async def ak_main(self, ctx: MyContext):
         """Kikoo filter configuration"""
         if ctx.subcommand_passed is None:
             await ctx.send_help("antikikoo")
 
     @ak_main.command(name="channel")
-    @commands.check(checks.is_admin)
+    @commands.has_permissions(administrator=True)
     async def ak_channel(self, ctx: MyContext, channel: discord.TextChannel):
         """Modifies the channel where members will have to check themselves"""
         self.bot.server_configs[ctx.guild.id]["verification_channel"] = channel.id
@@ -116,7 +117,7 @@ class Antikikoo(commands.Cog):
         )
 
     @ak_main.command(name="info_message")
-    @commands.check(checks.is_admin)
+    @commands.has_permissions(administrator=True)
     async def ak_msg(self, ctx: MyContext, *, message: str = None):
         """Modifies the informative message sent in the verification channel
         Put nothing to reset it, or "None" for no message"""

--- a/antikikoo/credits.md
+++ b/antikikoo/credits.md
@@ -1,6 +1,7 @@
 Copyright © ZRunner 2021
 Copyright © Leirof 2021 - 2022
 Copyright © Aeris One 2022
+Copyright © ascpial 2023
 
 Ce programme est régi par la licence CeCILL soumise au droit français et
 respectant les principes de diffusion des logiciels libres. Vous pouvez

--- a/channelArchive/channelArchive.py
+++ b/channelArchive/channelArchive.py
@@ -162,6 +162,7 @@ class ChannelArchive(commands.Cog):
 
     @commands.command(name="list_archive")
     @commands.guild_only()
+    @commands.has_permissions(manage_guild=True)
     async def list_archive(self, ctx: MyContext):
 
         config = self.bot.server_configs[ctx.guild.id]
@@ -239,6 +240,7 @@ class ChannelArchive(commands.Cog):
 
     @commands.command(name="archive")
     @commands.guild_only()
+    @commands.has_permissions(manage_channels=True, manage_permissions=True)
     async def archive(self, ctx: MyContext, channel: discord.TextChannel = None):
         """Archive a channel"""
 

--- a/channelArchive/credits.md
+++ b/channelArchive/credits.md
@@ -1,6 +1,6 @@
 Copyright © ZRunner 2020 - 2021
 Copyright © Leirof 2021 - 2022
-Copyright © ascpial 2021
+Copyright © ascpial 2021 - 2023
 Copyright © Aeris One 2022
 
 Ce programme est régi par la licence CeCILL soumise au droit français et

--- a/help/credits.md
+++ b/help/credits.md
@@ -1,4 +1,4 @@
-Copyright © ascpial 2021
+Copyright © ascpial 2021 - 2023
 Copyright © ZRunner 2021
 Copyright © Leirof 2021 - 2022
 Copyright © Aeris One 2022

--- a/messageManager/credits.md
+++ b/messageManager/credits.md
@@ -1,6 +1,7 @@
 Copyright © ZRunner 2021
 Copyright © Leirof 2021 - 2022
 Copyright © Aeris One 2022
+Copyright © ascpial 2023
 
 Ce programme est régi par la licence CeCILL soumise au droit français et
 respectant les principes de diffusion des logiciels libres. Vous pouvez

--- a/messageManager/messageManager.py
+++ b/messageManager/messageManager.py
@@ -51,17 +51,13 @@ class MessageManager(commands.Cog):
 
     @commands.command(name="imitate")
     @commands.guild_only()
+    @commands.has_permissions(manage_messages=True, manage_nicknames=True)
     async def imitate(
         self, ctx: commands.Context, user: discord.User = None, *, text=None
     ):
         """Say something with someone else's appearance"""
 
-        if (
-            user
-            and text
-            and ctx.channel.permissions_for(ctx.author).manage_messages
-            and ctx.channel.permissions_for(ctx.author).manage_nicknames
-        ):
+        if (user is not None and text is not None): # c'est python, autant être verbeux
             # Create a webhook in the image of the targeted member
             webhook = await ctx.channel.create_webhook(name=user.name)
             await webhook.send(content=text, avatar_url=user.display_avatar)
@@ -76,6 +72,11 @@ class MessageManager(commands.Cog):
 
     @commands.command(names="move", aliases=["mv"])
     @commands.guild_only()
+    @commands.has_permissions(
+        manage_messages=True,
+        read_messages=True,
+        read_message_history=True,
+    )
     async def move(
         self,
         ctx: commands.Context,
@@ -120,12 +121,7 @@ class MessageManager(commands.Cog):
             return
 
         # Check permission
-        if (
-            not ctx.channel.permissions_for(ctx.author).manage_messages
-            or not ctx.channel.permissions_for(ctx.author).read_messages
-            or not ctx.channel.permissions_for(ctx.author).read_message_history
-            or not channel.permissions_for(author).manage_messages
-        ):
+        if (not channel.permissions_for(author).manage_messages):
             embed = discord.Embed(
                 description=await self.bot._(
                     ctx.guild.id, "message_manager.permission"
@@ -173,6 +169,11 @@ class MessageManager(commands.Cog):
 
     @commands.command(names="moveall", aliases=["mva"])
     @commands.guild_only()
+    @commands.has_permissions(
+        manage_messages=True,
+        read_messages=True,
+        read_message_history=True,
+    )
     async def moveall(
         self,
         ctx: commands.Context,
@@ -219,12 +220,7 @@ class MessageManager(commands.Cog):
             return
 
         # Check member permissions
-        if (
-            not ctx.channel.permissions_for(ctx.author).manage_messages
-            or not ctx.channel.permissions_for(ctx.author).read_messages
-            or not ctx.channel.permissions_for(ctx.author).read_message_history
-            or not channel.permissions_for(author).manage_messages
-        ):
+        if (not channel.permissions_for(author).manage_messages):
             embed = discord.Embed(
                 description=await self.bot._(
                     ctx.guild.id, "message_manager.permission"

--- a/roleLink/credits.md
+++ b/roleLink/credits.md
@@ -1,6 +1,7 @@
 Copyright © ZRunner 2021
 Copyright © Leirof 2022 - 2022
 Copyright © Aeris One 2022
+Copyright © ascpial 2023
 
 Ce programme est régi par la licence CeCILL soumise au droit français et
 respectant les principes de diffusion des logiciels libres. Vous pouvez

--- a/roleLink/roleLink.py
+++ b/roleLink/roleLink.py
@@ -270,13 +270,14 @@ class GroupRoles(commands.Cog):
 
     @commands.group(name="rolelink")
     @commands.guild_only()
+    @commands.has_permissions(manage_guild=True)
     async def rolelink_main(self, ctx: commands.Context):
         """Manage your roles-links"""
         if ctx.subcommand_passed is None:
             await ctx.send_help("rolelink")
 
     @rolelink_main.command(name="add")
-    @commands.check(checks.is_server_manager)
+    @commands.has_permissions(manage_guild=True)
     async def rolelink_create(
         self,
         ctx: commands.Context,
@@ -328,6 +329,7 @@ class GroupRoles(commands.Cog):
 
     @rolelink_main.command(name="list")
     @commands.cooldown(1, 10, commands.BucketType.guild)
+    @commands.has_permissions(manage_guild=True)
     async def rolelink_list(self, ctx: commands.Context):
         """List your roles-links"""
         actions = self.db_get_config(ctx.guild.id)
@@ -342,7 +344,7 @@ class GroupRoles(commands.Cog):
         await ctx.send(txt)
 
     @rolelink_main.command(name="remove")
-    @commands.check(checks.is_server_manager)
+    @commands.has_permissions(manage_guild=True)
     async def rolelink_delete(self, ctx: commands.Context, id: int):
         """Delete one of your roles-links"""
         deleted = self.db_delete_action(ctx.guild.id, id)

--- a/xp/credits.md
+++ b/xp/credits.md
@@ -1,6 +1,6 @@
 Copyright © ZRunner 2021 - 2022
 Copyright © Leirof 2021 - 2022
-Copyright © ascpial 2021
+Copyright © ascpial 2021 - 2023
 Copyright © Aeris One 2022
 
 Ce programme est régi par la licence CeCILL soumise au droit français et

--- a/xp/xp.py
+++ b/xp/xp.py
@@ -734,6 +734,7 @@ class XP(commands.Cog):
         return True
 
     @commands.group(name="roles_levels")
+    @commands.has_permissions(manage_guild=True)
     @commands.guild_only()
     async def rr_main(self, ctx: MyContext):
         """Manage your roles rewards like a boss"""


### PR DESCRIPTION
Règles les problèmes d'affichage de permission refusée en n'affichant pas la commande dans le message d'aide si l'utilisateur ne dispose pas de la permission pour utiliser la commande.

Closes #15.
Closes #14.