### PR TITLE
ℹ Rss command without arguments works

### DIFF
--- a/rss/credits.md
+++ b/rss/credits.md
@@ -1,6 +1,6 @@
 Copyright © ZRunner 2021
 Copyright © Leirof 2021 - 2022
-Copyright © ascpial 2022
+Copyright © ascpial 2022 - 2023
 Copyright © Aeris One 2022
 
 Ce programme est régi par la licence CeCILL soumise au droit français et

--- a/rss/rss.py
+++ b/rss/rss.py
@@ -187,7 +187,7 @@ class Rss(commands.Cog):
     async def rss_main(self, ctx: MyContext):
         """See the last post of a rss feed"""
         if ctx.subcommand_passed is None:
-            await self.bot.get_cog("Help").help_command(ctx, ["rss"])
+            await ctx.send_help('rss')
 
     @rss_main.command(name="youtube", aliases=["yt"])
     async def request_yt(self, ctx: MyContext, ID):


### PR DESCRIPTION
La commande `!rss` n'affichait pas l'aide correctement car elle utilisait le système de ZBot.

Closes #37.